### PR TITLE
Removed a ` caracter that is an accent and not an apostrophe

### DIFF
--- a/Controller/UserController.php
+++ b/Controller/UserController.php
@@ -337,7 +337,7 @@ $email->replyTo(Configure::read('Authake.systemReplyTo'));
                     $this->Email->from = Configure::read('Authake.systemEmail');
                     $this->Email->sendAs = 'html';
                     $this->Email->charset = 'utf-8';
-                    $this->Email->template = '`Authake.lost_password'; 
+                    $this->Email->template = 'Authake.lost_password'; 
                     //Set the code into template
                     $this->set('code', $user['User']['passwordchangecode']);
                     $this->set('service', Configure::read('Authake.service'));


### PR DESCRIPTION
There is a '`call where on line 340 where the` is not useful and leads to a crash when trying to access the lost password feature
